### PR TITLE
Add SCTransform normalization option

### DIFF
--- a/pysces/README.md
+++ b/pysces/README.md
@@ -57,6 +57,9 @@ adata = pysces.read_census_direct(
 # Preprocess data
 adata = pysces.preprocess_data(adata)
 
+# Alternatively, you can use SCTransform normalization
+# adata = pysces.preprocess_data(adata, norm_method="sctransform")
+
 # Run ARACNe
 aracne = pysces.ARACNe(
     p_value=1e-8,              # P-value threshold for MI significance

--- a/pysces/examples/viper_example.py
+++ b/pysces/examples/viper_example.py
@@ -68,8 +68,8 @@ def main():
         adata = adata[:, gene_indices]
 
     # Preprocess the data
-    print("Preprocessing data...")
-    adata = preprocess_data(adata)
+    print("Preprocessing data with SCTransform...")
+    adata = preprocess_data(adata, norm_method="sctransform")
 
     # Get a list of transcription factors
     print("Loading transcription factors...")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+import anndata as ad
+import pysces
+
+
+def test_sctransform_normalization():
+    n_cells = 10
+    n_genes = 20
+    X = np.random.poisson(1, (n_cells, n_genes))
+    adata = ad.AnnData(X=X, var=pd.DataFrame(index=[f"gene_{i}" for i in range(n_genes)]))
+    processed = pysces.preprocess_data(
+        adata,
+        min_genes=0,
+        min_cells=0,
+        normalize=True,
+        norm_method="sctransform",
+    )
+    assert processed.shape == (n_cells, n_genes)
+


### PR DESCRIPTION
## Summary
- extend `preprocess_data` with a `norm_method` argument
- implement SCTransform normalization via `scanpy.experimental.pp.normalize_sctransform`
- regression test for the new option
- clarify docs and examples while keeping CPM as the default method

## Testing
- `pytest -q` *(fails: command not found)*